### PR TITLE
help bigquery understand

### DIFF
--- a/R/model-xgboost.R
+++ b/R/model-xgboost.R
@@ -145,7 +145,7 @@ build_fit_formula_xgb <- function(parsedmodel) {
     assigned <- 1
   } else if (objective %in% c("binary:logistic", "reg:logistic")) {
     assigned <- 1
-    f <- expr(1 - 1 / (1 + exp(!!f + binomial()$linkfun(!!base_score))))
+    f <- expr(1 - 1 / (1 + exp(!!f + log(!!base_score / (1 - !!base_score)))))
   }
   if (assigned == 0) {
     stop("Only objectives 'binary:logistic', 'reg:squarederror', 'reg:logistic', 'binary:logitraw' are supported yet.")


### PR DESCRIPTION
Turns out dbplyr can't translate `binomial()$linkfun` to SQL. (The error message was super unhelpful: `No applicable method for "escape" applied to an object of class "family"`). After fixing the [params bug](https://github.com/decktools/bonanza/pull/323), it turns out we were actually _hitting_ this chunk of code, correctly, but it's also buggy!! (when translated to SQL).

We are in luck though, `binomial()$linkfun` is just the logit, which is log(x / 1-x), and dbplyr does understand that 🎉 