### PR TITLE
bump our fork version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,12 +1,12 @@
 Package: tidypredict
-Version: 0.4.8.9000
+Version: 0.4.8.9001
 Title: Run Predictions Inside the Database
 Description: It parses a fitted 'R' model object, and returns a formula
     in 'Tidy Eval' code that calculates the predictions.
     It works with several databases back-ends because it leverages 'dplyr'
     and 'dbplyr' for the final 'SQL' translation of the algorithm. It currently
     supports lm(), glm(), randomForest(), ranger(), earth(), xgb.Booster.complete(),
-    cubist(), and ctree() models. 
+    cubist(), and ctree() models.
 Authors@R:
     person("Max", "Kuhn", email = "max@rstudio.com", role = c("aut", "cre"))
 Depends:

--- a/R/model-xgboost.R
+++ b/R/model-xgboost.R
@@ -116,7 +116,7 @@ get_xgb_case <- function(path, prediction, digits = NA) {
 get_xgb_case_tree <- function(tree_no, parsedmodel, digits = NA) {
   purrr::map(
     parsedmodel$trees[[tree_no]],
-    ~ get_xgb_case(.x$path, .x$prediction, digits)
+    ~ get_xgb_case(.x$path, round(.x$prediction, 3), digits)
   )
 }
 


### PR DESCRIPTION
Keeping the version of this fork the same as the original tidypredict fork (and possibly as a suitable version for the CRAN tidypredict) made it so our new confetti installation didn't realize it should replace our previously-installed version with this one. This PR changes our version (by a tiny tiny amount!! lol) from the dev version / main fork of tidypredict, and I'm going to see if I can peg a version in the confetti DESCRIPTION to ensure this one gets installed.

This PR also makes one last change to our fork, which is, when creating a decision tree SQL query, to round the outcome of the query to 3 decimal points. This makes it so instead of doing scoring by using a query like

`select p_turnout as case when age > 50.54234234324234 then 0.7923842384723847 else 0.2123129387891273 end`

it does

`select p_turnout as case when age > 50.54 then 0.792 else 0.213`

(the rounding of the age cutoff in this example is my original impetus for this fork and the difference in the `tidypredict:::get_xgb_case` function I look for; the rounding of the outcome probabilities to 3 decimal places is the `3` in this PR. This all helps us keep our queries under the bigquery character limit!)